### PR TITLE
edit_top_page_view

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show, :new, :create, :search]
+  before_action :move_to_index, unless: :user_signed_in?, only: :new
 
   def index
     @ladies = Item.set_index(category_id: 14..211)
@@ -53,5 +54,9 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :content, :category_id, :brand_id, :size_id, :delivery_burden, :delivery_method, :prefecture_id, :delivery_date, :price, :item_condition, item_images_attributes:[:image]).merge(user_id: current_user.id, sales_status: 0)
+  end
+
+  def move_to_index
+    redirect_to new_user_session_path
   end
 end

--- a/app/views/items/_index.html.haml
+++ b/app/views/items/_index.html.haml
@@ -1,33 +1,37 @@
 %section.pickup-container
   %h2.pickup-head ピックアップカテゴリー
   %section.items-box-container
-    %h3.text-center
-      = link_to "レディース新着アイテム", items_path, class: 'genre'
-    .items-box-content
-      = render 'items/toppage/ladies'
-    .view-all
-      = link_to "すべての商品を見る", items_path, class: 'all-link'
-    %section.items-box-container
-    %h3.text-center
-      = link_to "メンズ新着アイテム", items_path, class: 'genre'
-    .items-box-content
-      = render 'items/toppage/mens'
-    .view-all
-      = link_to "すべての商品を見る", items_path, class: 'all-link'
-    %section.items-box-container
-    %h3.text-center
-      = link_to "ベビー・キッズ新着アイテム", items_path, class: 'genre'
-    .items-box-content
-      = render 'items/toppage/kids'
-    .view-all
-      = link_to "すべての商品を見る", items_path, class: 'all-link'
-    %section.items-box-container
-    %h3.text-center
-      = link_to "コスメ・香水・美容キッズ新着アイテム", items_path, class: 'genre'
-    .items-box-content
-      = render 'items/toppage/cosme'
-    .view-all
-      = link_to "すべての商品を見る", items_path, class: 'all-link'
+    - if @ladies.present?
+      %h3.text-center
+        = link_to "レディース新着アイテム", items_path, class: 'genre'
+      .items-box-content
+        = render 'items/toppage/ladies'
+      .view-all
+        = link_to "すべての商品を見る", items_path, class: 'all-link'
+  %section.items-box-container
+    - if @mens.present?
+      %h3.text-center
+        = link_to "メンズ新着アイテム", items_path, class: 'genre'
+      .items-box-content
+        = render 'items/toppage/mens'
+      .view-all
+        = link_to "すべての商品を見る", items_path, class: 'all-link'
+  %section.items-box-container
+    - if @kids.present?
+      %h3.text-center
+        = link_to "ベビー・キッズ新着アイテム", items_path, class: 'genre'
+      .items-box-content
+        = render 'items/toppage/kids'
+      .view-all
+        = link_to "すべての商品を見る", items_path, class: 'all-link'
+  %section.items-box-container
+    - if @cosme.present?
+      %h3.text-center
+        = link_to "コスメ・香水・美容キッズ新着アイテム", items_path, class: 'genre'
+      .items-box-content
+        = render 'items/toppage/cosme'
+      .view-all
+        = link_to "すべての商品を見る", items_path, class: 'all-link'
 %section.pickup-container
   %h2.pickup-head ピックアップブランド
   %section.items-box-container
@@ -38,24 +42,27 @@
     .view-all
       = link_to "すべての商品を見る", items_path, class: 'all-link'
   %section.items-box-container
-    %h3.text-center
-      = link_to "ルイヴィトン新着アイテム", items_path, class: 'genre'
-    .items-box-content
-      = render 'items/toppage/vuitton'
-    .view-all
-      = link_to "すべての商品を見る", items_path, class: 'all-link'
+    - if @vuitton.present?
+      %h3.text-center
+        = link_to "ルイヴィトン新着アイテム", items_path, class: 'genre'
+      .items-box-content
+        = render 'items/toppage/vuitton'
+      .view-all
+        = link_to "すべての商品を見る", items_path, class: 'all-link'
   %section.items-box-container
-    %h3.text-center
-      = link_to "シュプリーム新着アイテム", items_path, class: 'genre'
-    .items-box-content
-      = render 'items/toppage/supreme'
-    .view-all
-      = link_to "すべての商品を見る", items_path, class: 'all-link'
-    %section.items-box-container
-    %h3.text-center
-      = link_to "ナイキ新着アイテム", items_path, class: 'genre'
-    .items-box-content
-      = render 'items/toppage/nike'
-    .view-all
-      = link_to "すべての商品を見る", items_path, class: 'all-link'
+    - if @supreme.present?
+      %h3.text-center
+        = link_to "シュプリーム新着アイテム", items_path, class: 'genre'
+      .items-box-content
+        = render 'items/toppage/supreme'
+      .view-all
+        = link_to "すべての商品を見る", items_path, class: 'all-link'
+  %section.items-box-container
+    - if @nike.present?
+      %h3.text-center
+        = link_to "ナイキ新着アイテム", items_path, class: 'genre'
+      .items-box-content
+        = render 'items/toppage/nike'
+      .view-all
+        = link_to "すべての商品を見る", items_path, class: 'all-link'
 =render 'shared/sell_btn'


### PR DESCRIPTION
トップページのカテゴリーにアイテムがない場合は、そのカテゴリーは表示させないように変更。
ログインしていない時に出品ボタンを押すとログインページに遷移するように修正。