### PR TITLE
バリデーションに伴うエラーメッセージを表示

### DIFF
--- a/app/assets/stylesheets/modules/form.scss
+++ b/app/assets/stylesheets/modules/form.scss
@@ -2,6 +2,15 @@
 
 }
 
+.error-messages {
+  color: $red;
+  margin: 0 auto 20px auto;
+  background-color: $light-gray;
+  p {
+    text-align: center;
+  }
+}
+
 .field {
   max-width: 320px;
   margin: 0 auto;

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -65,7 +65,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
         redirect_to signup_sms_confirmation_path(@user)
       else
         @active = ['active', '', '', '', '']
-        render :reg_first_view, locals: {active: @active}, layout: 'user_registration2'
+        @error = @user.errors.full_messages.push(@user_profile.errors.full_messages).flatten!
+        render :reg_first_view, locals: {active: @active, error: @error}, layout: 'user_registration2'
       end
     end
 
@@ -79,7 +80,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
       redirect_to signup_sms_confirmation_sms_path
     else
       @active = ['active', 'active', '', '', '']
-      render :reg_second_view, locals: {active: @active}, layout: 'user_registration2'
+      @error = @user_profile.errors.full_messages
+      render :reg_second_view, locals: {active: @active, error: @error}, layout: 'user_registration2'
     end
   end
 
@@ -90,7 +92,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
       redirect_to signup_input_address_path
     else
       @active = ['active', 'active', '', '', '']
-      render :reg_third_view, locals: {active: @active}, layout: 'user_registration2'
+      @error = @user.errors.full_messages
+      render :reg_third_view, locals: {active: @active, error: @error}, layout: 'user_registration2'
     end
   end
 
@@ -107,7 +110,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @active = ['active', 'active', 'active', '', '']
       @user = User.find(@user_id)
       @prefectures = Prefecture.all
-      render :reg_forth_view, locals: {active: @active, user: @user, prefectures: @prefectures}, layout: 'user_registration2'
+      @error = @user_profile.errors.full_messages
+      render :reg_forth_view, locals: {active: @active, user: @user, prefectures: @prefectures, error: @error}, layout: 'user_registration2'
     end
   end
 
@@ -118,7 +122,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
       redirect_to signup_complete_path
     else
       @active = ['active', 'active', 'active', 'active', '']
-      render :reg_fifth_view, locals: {active: @active}, layout: 'user_registration2'
+      @error = @credit.errors.full_messages
+      render :reg_fifth_view, locals: {active: @active, error: @error}, layout: 'user_registration2'
     end
   end
 

--- a/app/views/users/registrations/reg_fifth_view.html.haml
+++ b/app/views/users/registrations/reg_fifth_view.html.haml
@@ -2,6 +2,11 @@
   %h2.head-title
     支払い方法
   .content-head
+    - if @error
+      .error-messages
+        - @error.each do |error|
+          %p
+            = error
     .content-inner-form
       = form_tag("/signup/input_payment", method: "post") do
         .field

--- a/app/views/users/registrations/reg_first_view.html.haml
+++ b/app/views/users/registrations/reg_first_view.html.haml
@@ -2,6 +2,11 @@
   %h2.head-title
     会員情報入力
   .content-head
+    - if @error
+      .error-messages
+        - @error.each do |error|
+          %p
+            = error
     .content-inner-form
       = form_tag("/signup/registration", method: "post") do
         .field
@@ -23,13 +28,13 @@
               = label_tag(:password, "パスワード")
             .field-necessary
               %span 必須
-          = text_field_tag :password, nil, {placeholder: '6文字以上', class: 'field-input'}
+          = password_field_tag :password, nil, {placeholder: '6文字以上', class: 'field-input'}
           .field-title.clearfix
             .field-label
               = label_tag(:password_confirmation, "パスワード(確認)")
             .field-necessary
               %span 必須
-          = text_field_tag :password_confirmation, nil, {placeholder: '6文字以上', class: 'field-input'}
+          = password_field_tag :password_confirmation, nil, {placeholder: '6文字以上', class: 'field-input'}
         .field-text
           %h3.text-title 本人確認
           %p.text-content 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。

--- a/app/views/users/registrations/reg_forth_view.html.haml
+++ b/app/views/users/registrations/reg_forth_view.html.haml
@@ -2,6 +2,11 @@
   %h2.head-title
     発送元・お届け先住所入力
   .content-head
+    - if @error
+      .error-messages
+        - @error.each do |error|
+          %p
+            = error
     .content-inner-form
       = form_tag("/signup/input_address", method: "post") do
         .field

--- a/app/views/users/registrations/reg_second_view.html.haml
+++ b/app/views/users/registrations/reg_second_view.html.haml
@@ -2,6 +2,11 @@
   %h2.head-title
     電話番号の確認
   .content-head
+    - if @error
+      .error-messages
+        - @error.each do |error|
+          %p
+            = error
     .content-inner-form
       = form_tag("/signup/sms_confirmation", method: "post") do
         .field

--- a/app/views/users/registrations/reg_third_view.html.haml
+++ b/app/views/users/registrations/reg_third_view.html.haml
@@ -2,6 +2,11 @@
   %h2.head-title
     電話番号認証
   .content-head
+    - if @error
+      .error-messages
+        - @error.each do |error|
+          %p
+            = error
     .content-inner-form
       = form_tag("/signup/sms_confirmation/sms", method: "post") do
         .field

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190603171545) do
+ActiveRecord::Schema.define(version: 20190606094744) do
 
   create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",       default: ""
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20190603171545) do
     t.integer  "item_condition",                null: false
     t.integer  "delivery_burden",               null: false
     t.integer  "delivery_method",               null: false
+    t.string   "prefecture_id",                 null: false
     t.integer  "delivery_date",                 null: false
     t.integer  "price",                         null: false
     t.integer  "sales_status",                  null: false
@@ -148,6 +149,7 @@ ActiveRecord::Schema.define(version: 20190603171545) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.integer  "certification_number"
+    t.string   "access_token"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
# what
アカウント登録時にバリデーションで弾かれても、なぜ弾かれたのかユーザーに表示されなかったため、バリデーションに伴うエラーメッセージを表示させる
passwordの入力時に内容が見えてしまうため、非表示に修正（text_field_tag => password_field_tag）

# why
エラーメッセージが表示されないとなぜ弾かれたかわからない
passwordが見えてしまうとセキュリティ上問題がある