### PR TITLE
エラーメッセージのカラム名を日本語化

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,22 @@
 ---
 ja:
   activerecord:
+    models:
+      user: ユーザー
+      user_profile: ユーザープロフィール
+      credit: クレジット
+    attributes:
+      user:
+        nickname: ニックネーム
+        email: メールアドレス
+        password: パスワード
+      user_profile:
+        lastname: 姓
+        firstname: 名
+        lastname_kana: セイ
+        firstname_kana: メイ
+        prefecture: 都道府県
+        phone_number: 電話番号
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'
@@ -107,7 +123,7 @@ ja:
       month: 月
       year: 年
   errors:
-    format: "%{attribute}%{message}"
+    format: "%{message}"
     messages:
       accepted: を受諾してください
       blank: "%{attribute}を入力してください"
@@ -205,24 +221,3 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
-  models:
-    user: ユーザー
-    user_profile: ユーザープロフィール
-    credit: クレジット
-#  attributes:
-#    user:
-#      nickname: ニックネーム
-#      email: メールアドレス
-#      password: パスワード
-#    user_profile:
-#      lastname: 姓
-#      firstname: 名
-#      lastname_kana: セイ
-#      firstname_kana: メイ
-#      prefecture: 都道府県
-#      phone_number: 電話番号
-#    credit:
-#      card_number: カード番号
-#      expiration_month: 期限（月）
-#      expiration_year: 期限（年）
-#      security_code: セキュリティコード

--- a/spec/models/user_profile_spec.rb
+++ b/spec/models/user_profile_spec.rb
@@ -7,20 +7,20 @@ describe UserProfile do
                                      postal_code: "", prefecture: "", city: "", block_number: "", building_name: "",
                                      phone_number: 1234567)
       user_profile.valid?
-      expect(user_profile.errors[:lastname]).to include("Lastnameを入力してください")
-      expect(user_profile.errors[:firstname]).to include("Firstnameを入力してください")
-      expect(user_profile.errors[:lastname_kana]).to include("Lastname kanaを入力してください")
-      expect(user_profile.errors[:firstname_kana]).to include("Firstname kanaを入力してください")
+      expect(user_profile.errors[:lastname]).to include("姓を入力してください")
+      expect(user_profile.errors[:firstname]).to include("名を入力してください")
+      expect(user_profile.errors[:lastname_kana]).to include("セイを入力してください")
+      expect(user_profile.errors[:firstname_kana]).to include("カナを入力してください")
       expect(user_profile.errors[:birth_year]).to include("Birth yearを入力してください")
       expect(user_profile.errors[:birth_month]).to include("Birth monthを入力してください")
       expect(user_profile.errors[:birth_day]).to include("Birth dayを入力してください")
 
       user_profile.valid?(:phone_number_validates)
-      expect(user_profile.errors[:phone_number]).to include("は8文字以上で入力してください")
+      expect(user_profile.errors[:phone_number]).to include("電話番号は8文字以上で入力してください")
 
       user_profile.valid?(:address)
-      expect(user_profile.errors[:postal_code]).to include("Postal codeを入力してください")
-      expect(user_profile.errors[:prefecture]).to include("Prefectureを入力してください")
+      expect(user_profile.errors[:postal_code]).to include("郵便番号を入力してください")
+      expect(user_profile.errors[:prefecture]).to include("都道府県を入力してください")
       expect(user_profile.errors[:city]).to include("Cityを入力してください")
       expect(user_profile.errors[:block_number]).to include("Block numberを入力してください")
       expect(user_profile.errors[:building_name]).to include("Building nameを入力してください")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,20 +11,20 @@ describe User do
     it "is invalid without nickname" do
       user = build(:user, nickname: "")
       user.valid?
-      expect(user.errors[:nickname]).to include("Nicknameを入力してください")
+      expect(user.errors[:nickname]).to include("ニックネームを入力してください")
 
     end
 
     it "is invalid without email" do
       user = build(:user, email: "")
       user.valid?
-      expect(user.errors[:email]).to include("Emailを入力してください")
+      expect(user.errors[:email]).to include("メールアドレスを入力してください")
     end
 
     it "is invalid without password" do
       user = build(:user, password: "")
       user.valid?
-      expect(user.errors[:password]).to include("Passwordを入力してください")
+      expect(user.errors[:password]).to include("パスワードを入力してください")
     end
   end
 end


### PR DESCRIPTION
# what
エラーメッセージのカラムが日本語化されていなかったため、日本語化を行った

# why
エラーメッセージがわかりにくかったため